### PR TITLE
Add linker flags for webserve on Windows.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,11 @@
 # Makefile for compiling required oct files
 
+MKOCTFILE ?= mkoctfile
+
+# libraries with functions for socket connections
+ifneq (,$(findstring mingw,$(shell $(MKOCTFILE) -p CANONICAL_HOST_TYPE)))
+SOCK_LIBS ?= -lws2_32 -lwsock32
+endif
+
 all:
-	$(MKOCTFILE)       webserve.cc
+	$(MKOCTFILE) webserve.cc $(SOCK_LIBS)


### PR DESCRIPTION
This seems to be working for me locally on Windows. Haven't tested if this breaks anything on Linux.

See also: https://octave.discourse.group/t/how-to-use-ctrl-c-signal-to-terminate-a-crow-instance-inside-an-oct-function/5896/20