### PR TITLE
Remove "octave-" from package name.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Name: octave-chartjs
+Name: chartjs
 Version: 0.1.0
 Date: 2024-09-22
 Author: Andreas Bertsatos


### PR DESCRIPTION
Most Octave packages don't have "octave" in their name. (None of the 50+ packages that are bundled with Octave for Windows start with "octave".)

Remove "octave-" and name the package "chartjs".