### PR TITLE
Start hiding internal WebServer class from user

### DIFF
--- a/inst/Html.m
+++ b/inst/Html.m
@@ -114,7 +114,11 @@ classdef Html
     ##
     ## @code{webserve (@var{obj})} serves the HTML describing the Chart object
     ## to a web server.  If the web server hasn't started yet, it is initialized
-    ## with default settings.
+    ## automatically with default settings.
+    ##
+    ## If the server should run with non-default settings, use the
+    ## @code{webinitialize} method before calling the @code{webserve} method of
+    ## any of the @obj{*Chart} class objects to initialize the server manually.
     ##
     ## @seealso{BarChart, BubbleChart, DoughnutChart, LineChart, PieChart,
     ## PolarAreaChart, RadarChart, ScatterChart, WebServer}
@@ -125,6 +129,38 @@ classdef Html
       webserver = WebServer.start ();
 
       webserver.update (this);
+
+    endfunction
+
+    ## -*- texinfo -*-
+    ## @deftypefn  {chartjs} {} webinitialize (@var{obj})
+    ## @deftypefnx {chartjs} {} webinitialize (@var{obj}, @var{Name}, @var{Value}, @dots{})
+    ##
+    ## Initialize a WebServer instance.
+    ##
+    ## @code{webinitialize (@var{obj})} initializes a web server instance,
+    ## which by default listens to the @qcode{localhost} on port @qcode{8080}.
+    ##
+    ## @code{webinitialize (@var{obj}, @var{Name}, @var{Value}, @dots{})}
+    ## initializes a web server instance with the settings specified by one or
+    ## more of the following @qcode{@var{Name}, @var{Value}} pair arguments.
+    ##
+    ## @multitable @columnfractions 0.18 0.02 0.80
+    ## @headitem @var{Name} @tab @tab @var{Value}
+    ##
+    ## @item @qcode{port} @tab @tab A numeric integer value specifying the
+    ## listening port of the web server instance.  The default value is 8080.
+    ##
+    ## @item @qcode{bind-address} @tab @tab A character vector specifying the
+    ## bind-address of the web server instance.  The default value is
+    ## @qcode{"127.0.0.1"}.
+    ##
+    ## @seealso{WebServer}
+    ## @end deftypefn
+
+    function webinitialize (this, varargin)
+
+      WebServer.start (varargin{:});
 
     endfunction
 

--- a/inst/Html.m
+++ b/inst/Html.m
@@ -109,26 +109,40 @@ classdef Html
 
     ## -*- texinfo -*-
     ## @deftypefn  {chartjs} {} webserve (@var{obj})
+    ## @deftypefn  {chartjs} {} webserve (@var{obj}, @var{html})
     ##
     ## Serve Chart online.
     ##
     ## @code{webserve (@var{obj})} serves the HTML describing the Chart object
-    ## to a web server.  If the web server hasn't started yet, it is initialized
-    ## automatically with default settings.
+    ## to a web server.
     ##
-    ## If the server should run with non-default settings, use the
-    ## @code{webinitialize} method before calling the @code{webserve} method of
-    ## any of the @obj{*Chart} class objects to initialize the server manually.
+    ## @code{webserve (@var{obj}, @var{html})} serves the string @var{html}
+    ## to a web server.  This could be a (modified) version of the string
+    ## returned by the method @code{htmlstring}.
+    ##
+    ## If the web server has not started yet, it is initialized automatically
+    ## with default settings.  If the server should run with non-default
+    ## settings, use the @code{webinitialize} method before calling the
+    ## @code{webserve} method of any of the @obj{*Chart} class objects to
+    ## initialize the server manually.
     ##
     ## @seealso{BarChart, BubbleChart, DoughnutChart, LineChart, PieChart,
     ## PolarAreaChart, RadarChart, ScatterChart, WebServer}
     ## @end deftypefn
 
-    function webserve (this)
+    function webserve (this, html)
+
+      if (nargin > 1 && ! ischar (html))
+        error ("webserve: input argument must be a string")
+      endif
 
       webserver = WebServer.start ();
 
-      webserver.update (this);
+      if (nargin > 1)
+        webserver.update (html);
+      else
+        webserver.update (this);
+      endif
 
     endfunction
 

--- a/inst/Html.m
+++ b/inst/Html.m
@@ -136,12 +136,12 @@ classdef Html
         error ("webserve: input argument must be a string")
       endif
 
-      webserver = WebServer.start ();
+      webserver = WebServer ();
 
       if (nargin > 1)
-        webserver.update (html);
+        webserver.serve (html);
       else
-        webserver.update (this);
+        webserver.serve (this);
       endif
 
     endfunction
@@ -174,7 +174,7 @@ classdef Html
 
     function webinitialize (this, varargin)
 
-      WebServer.start (varargin{:});
+      WebServer.initialize (varargin{:});
 
     endfunction
 

--- a/inst/Html.m
+++ b/inst/Html.m
@@ -107,6 +107,27 @@ classdef Html
 
     endfunction
 
+    ## -*- texinfo -*-
+    ## @deftypefn  {chartjs} {} webserve (@var{obj})
+    ##
+    ## Serve Chart online.
+    ##
+    ## @code{webserve (@var{obj})} serves the HTML describing the Chart object
+    ## to a web server.  If the web server hasn't started yet, it is initialized
+    ## with default settings.
+    ##
+    ## @seealso{BarChart, BubbleChart, DoughnutChart, LineChart, PieChart,
+    ## PolarAreaChart, RadarChart, ScatterChart, WebServer}
+    ## @end deftypefn
+
+    function webserve (this)
+
+      webserver = WebServer.start ();
+
+      webserver.update (this);
+
+    endfunction
+
   endmethods
 
 endclassdef

--- a/inst/Html.m
+++ b/inst/Html.m
@@ -116,10 +116,6 @@ classdef Html
     ## @code{webserve (@var{obj})} serves the HTML describing the Chart object
     ## to a web server.
     ##
-    ## @code{webserve (@var{obj}, @var{html})} serves the string @var{html}
-    ## to a web server.  This could be a (modified) version of the string
-    ## returned by the method @code{htmlstring}.
-    ##
     ## If the web server has not started yet, it is initialized automatically
     ## with default settings.  If the server should run with non-default
     ## settings, use the @code{webinitialize} method before calling the
@@ -130,51 +126,11 @@ classdef Html
     ## PolarAreaChart, RadarChart, ScatterChart, WebServer}
     ## @end deftypefn
 
-    function webserve (this, html)
-
-      if (nargin > 1 && ! ischar (html))
-        error ("webserve: input argument must be a string")
-      endif
+    function webserve (this)
 
       webserver = WebServer ();
 
-      if (nargin > 1)
-        webserver.serve (html);
-      else
-        webserver.serve (this);
-      endif
-
-    endfunction
-
-    ## -*- texinfo -*-
-    ## @deftypefn  {chartjs} {} webinitialize (@var{obj})
-    ## @deftypefnx {chartjs} {} webinitialize (@var{obj}, @var{Name}, @var{Value}, @dots{})
-    ##
-    ## Initialize a WebServer instance.
-    ##
-    ## @code{webinitialize (@var{obj})} initializes a web server instance,
-    ## which by default listens to the @qcode{localhost} on port @qcode{8080}.
-    ##
-    ## @code{webinitialize (@var{obj}, @var{Name}, @var{Value}, @dots{})}
-    ## initializes a web server instance with the settings specified by one or
-    ## more of the following @qcode{@var{Name}, @var{Value}} pair arguments.
-    ##
-    ## @multitable @columnfractions 0.18 0.02 0.80
-    ## @headitem @var{Name} @tab @tab @var{Value}
-    ##
-    ## @item @qcode{port} @tab @tab A numeric integer value specifying the
-    ## listening port of the web server instance.  The default value is 8080.
-    ##
-    ## @item @qcode{bind-address} @tab @tab A character vector specifying the
-    ## bind-address of the web server instance.  The default value is
-    ## @qcode{"127.0.0.1"}.
-    ##
-    ## @seealso{WebServer}
-    ## @end deftypefn
-
-    function webinitialize (this, varargin)
-
-      WebServer.initialize (varargin{:});
+      webserver.serve (this);
 
     endfunction
 

--- a/inst/WebServer.m
+++ b/inst/WebServer.m
@@ -85,14 +85,19 @@ classdef WebServer < handle
 
     endfunction
 
-    ## Destructor
-    function delete (this)
-      __webserve__ (0);
-    endfunction
-
   endmethods
 
   methods
+
+    ## Destructor
+    ## NEVER CALL DESTRUCTOR FOR AN OBJECT OF THIS CLASS MANUALLY !!!
+
+    function delete (this)
+
+      # stop Crow server before exit
+      __webserve__ (0);
+
+    endfunction
 
     ## -*- texinfo -*-
     ## @deftypefn  {chartjs} {} update (@var{obj}, @var{ctx})

--- a/inst/WebServer.m
+++ b/inst/WebServer.m
@@ -1,0 +1,124 @@
+## Copyright (C) 2024 Andreas Bertsatos <abertsatos@biol.uoa.gr>
+##
+## This file is part of the statistics package for GNU Octave.
+##
+## This program is free software; you can redistribute it and/or modify it under
+## the terms of the GNU General Public License as published by the Free Software
+## Foundation; either version 3 of the License, or (at your option) any later
+## version.
+##
+## This program is distributed in the hope that it will be useful, but WITHOUT
+## ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+## FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+## details.
+##
+## You should have received a copy of the GNU General Public License along with
+## this program; if not, see <http://www.gnu.org/licenses/>.
+
+classdef WebServer
+## -*- texinfo -*-
+## @deftypefn  {chartjs} {@var{obj} =} WebServer ()
+##
+## Interface to a web server instance
+##
+## This class provides methods to initialize a web server and update the
+## HTML content that is served by it.
+##
+## @seealso{BarChart, BubbleChart, DoughnutChart, LineChart, PieChart,
+## PolarAreaChart, RadarChart, ScatterChart, WebServer}
+## @end deftypefn
+
+  properties (SetAccess = protected)
+
+    html;
+    addr;
+    port;
+
+  endproperties
+
+  methods (Access = public)
+
+    ## -*- texinfo -*-
+    ## @deftypefn  {chartjs} {} serve (@var{obj})
+    ## @deftypefn  {chartjs} {} serve (@var{obj}, @var{html})
+    ##
+    ## Serve HTML content.
+    ##
+    ## @code{serve (@var{obj}, @var{html})} serves the string @var{html}
+    ## to a web server.
+    ##
+    ## If the web server has not started yet, it is initialized automatically
+    ## with default settings.  If the server should run with non-default
+    ## settings, use the @code{initialize} method to initialize the server
+    ## manually before calling the @code{serve} method for the first time.
+    ##
+    ## @seealso{WebServer}
+    ## @end deftypefn
+
+    function serve (this, ctx)
+
+      ## Valid Chart objects
+      valid_charts = {"BarChart", "BubbleChart", "DoughnutChart", ...
+                      "LineChart", "PieChart", "PolarAreaChart", ...
+                      "RadarChart", "ScatterChart"};
+
+      ## Parse input argument
+      if (isobject (ctx))
+        ## Chart objects
+        if (any (isa (ctx, valid_charts)))
+          this.html = htmlstring (ctx);
+        else
+          error ("WebServer.serve: unsupported Chart object.");
+        endif
+
+      elseif (ischar (ctx))
+        this.html = ctx;
+      else
+        error ("WebServer.serve: invalid web content.");
+      endif
+
+      webserver = WebInstance.instance ();
+
+      webserver.serve (this.html);
+
+    endfunction
+
+    ## -*- texinfo -*-
+    ## @deftypefn  {chartjs} {} initialize (@var{obj})
+    ## @deftypefnx {chartjs} {} initialize (@var{obj}, @var{Name}, @var{Value}, @dots{})
+    ##
+    ## Initialize a WebServer instance.
+    ##
+    ## @code{initialize (@var{obj})} initializes a web server instance, which
+    ## by default listens to the @qcode{localhost} on port @qcode{8080}.
+    ##
+    ## @code{initialize (@var{obj}, @var{Name}, @var{Value}, @dots{})}
+    ## initializes a web server instance with the settings specified by one or
+    ## more of the following @qcode{@var{Name}, @var{Value}} pair arguments.
+    ##
+    ## @multitable @columnfractions 0.18 0.02 0.80
+    ## @headitem @var{Name} @tab @tab @var{Value}
+    ##
+    ## @item @qcode{port} @tab @tab A numeric integer value specifying the
+    ## listening port of the web server instance.  The default value is 8080.
+    ##
+    ## @item @qcode{bind-address} @tab @tab A character vector specifying the
+    ## bind-address of the web server instance.  The default value is
+    ## @qcode{"127.0.0.1"}.
+    ##
+    ## @seealso{WebServer}
+    ## @end deftypefn
+
+    function initialize (this, varargin)
+
+      webserver = WebInstance.instance (varargin{:});
+
+      this.html = webserver.html;
+      this.addr = webserver.addr;
+      this.port = webserver.port;
+
+    endfunction
+
+  endmethods
+
+endclassdef

--- a/inst/private/WebInstance.m
+++ b/inst/private/WebInstance.m
@@ -113,25 +113,11 @@ classdef WebInstance < handle
 
     function serve (this, ctx)
 
-      ## Valid Chart objects
-      valid_charts = {"BarChart", "BubbleChart", "DoughnutChart", ...
-                      "LineChart", "PieChart", "PolarAreaChart", ...
-                      "RadarChart", "ScatterChart"};
-
-      ## Parse input argument
-      if (isobject (ctx))
-        ## Chart objects
-        if (any (isa (ctx, valid_charts)))
-          this.html = htmlstring (ctx);
-        else
-          error ("WebServer.update: unsupported Chart object.");
-        endif
-
-      elseif (ischar (ctx))
-        this.html = ctx;
-      else
-        error ("WebServer.update: invalid web content.");
+      if (! ischar (ctx))
+        error ("WebInstance.serve: invalid web content.");
       endif
+
+      this.html = ctx;
 
       ## Update content
       __webserve__ (this.html);

--- a/inst/private/WebInstance.m
+++ b/inst/private/WebInstance.m
@@ -15,27 +15,27 @@
 ## You should have received a copy of the GNU General Public License along with
 ## this program; if not, see <http://www.gnu.org/licenses/>.
 
-classdef WebServer < handle
+classdef WebInstance < handle
 ## -*- texinfo -*-
-## @deftypefn  {chartjs} {@var{obj} =} html ()
+## @deftypefn  {chartjs} {@var{obj} =} WebInstance ()
 ##
 ## A GNU Octave WebServer instance.
 ##
 ## This class initializes a web server and returns its instance in a
-## @qcode{WebServer} object.  The web instance, once initiated by the class
+## @qcode{WebInstance} object.  The web instance, once initiated by the class
 ## constructor, it remains persistent during the Octave session and it is
 ## gracefully terminated upon exit by the class destructor.  The web instance is
 ## still valid and active even if the variable holding the instance in Octave's
-## workspace is deleted.  Both class constructor (i.e. @qcode{WebServer ()}) and
-## destructor (i.e. @qcode{delete (obj)}) functions are private and cannot be
-## run directly.  Use the static method @qcode{WebServer.start ()} to initiate a
-## web server instance or reacquire its handle in case the variable has been
-## accidentally cleared from the workspace.  Use the @qcode{update ()} public
-## method to update the contents being served by the web server instance.
+## workspace is deleted.  Both class constructor (i.e. @qcode{WebInstance ()})
+## and destructor (i.e. @qcode{delete (obj)}) functions are private and cannot
+## be run directly.  Use the static method @qcode{WebInstance.instance ()} to
+## initiate a web server instance or reacquire its handle.  Use the
+## @qcode{serve ()} method to update the contents that are being served by the
+## web server instance.
 ##
-## The @qcode{WebServer} class utilizes the @qcode{__webserve__} dynamically
+## The @qcode{WebInstance} class utilizes the @qcode{__webserve__} dynamically
 ## linked library, which relies relies on the CrowCpp microframework. Do NOT use
-## the @qcode{__webserve__} function directly!
+## the @qcode{__webserve__} function or the @qcode{WebInstance} class directly!
 ##
 ## @seealso{Html, WebServer}
 ## @end deftypefn
@@ -51,17 +51,17 @@ classdef WebServer < handle
   methods (Access = private)
 
     ## Constructor
-    function this = WebServer (varargin)
+    function this = WebInstance (varargin)
 
       ## Handle the optional pair arguments
       if (mod (numel (varargin), 2) != 0)
-        error ("WebServer: optional arguments must be in Name,Value pairs.");
+        error ("WebInstance: optional arguments must be in Name,Value pairs.");
       endif
       while (numel (varargin) > 0)
         switch (lower (varargin{1}))
           case "bind-address"
             if (! ischar (varargin{2}))
-              error ("WebServer: 'bindaddress' must be a character vector.");
+              error ("WebInstance: 'bindaddress' must be a character vector.");
             endif
             this.addr = varargin{2};
 
@@ -69,13 +69,13 @@ classdef WebServer < handle
             port = varargin{2};
             if (! (isnumeric (port) && isscalar (port) &&
                    fix (port) == port && port > 0 && port <= 65535))
-              error (strcat (["WebServer: 'port' must be a scalar"], ...
+              error (strcat (["WebInstance: 'port' must be a scalar"], ...
                              [" integer value assigning a valid port."]));
             endif
             this.port = port;
 
           otherwise
-            error ("WebServer: unknown optional argument.");
+            error ("WebInstance: unknown optional argument.");
         endswitch
         varargin([1:2]) = [];
       endwhile
@@ -100,19 +100,18 @@ classdef WebServer < handle
     endfunction
 
     ## -*- texinfo -*-
-    ## @deftypefn  {chartjs} {} update (@var{obj}, @var{ctx})
+    ## @deftypefn  {chartjs} {} serve (@var{obj}, @var{ctx})
     ##
     ## Update the WebServer's content.
     ##
-    ## @code{update (@var{obj}, @var{ctx})} updates the content served by a
+    ## @code{serve (@var{obj}, @var{ctx})} updates the content served by a
     ## WebServer instance, @var{obj}.  @var{ctx} can either be a @qcode{*Chart}
     ## object or a character vector containing any text/HTML string.
     ##
-    ## @seealso{BarChart, BubbleChart, DoughnutChart, LineChart, PieChart,
-    ## PolarAreaChart, RadarChart, ScatterChart, WebServer}
+    ## @seealso{WebServer}
     ## @end deftypefn
 
-    function update (this, ctx)
+    function serve (this, ctx)
 
       ## Valid Chart objects
       valid_charts = {"BarChart", "BubbleChart", "DoughnutChart", ...
@@ -144,18 +143,20 @@ classdef WebServer < handle
   methods (Static)
 
     ## -*- texinfo -*-
-    ## @deftypefn  {chartjs} {@var{obj} =} WebServer.start ()
-    ## @deftypefnx {chartjs} {@var{obj} =} WebServer.start (@var{Name}, @var{Value}, @dots{})
+    ## @deftypefn  {chartjs} {@var{obj} =} WebInstance.instance ()
+    ## @deftypefnx {chartjs} {@var{obj} =} WebInstance.instance (@var{Name}, @var{Value}, @dots{})
     ##
-    ## Initialize a WebServer instance.
+    ## Get a WebServer instance.
     ##
-    ## @code{@var{obj} = WebServer.start ()} initializes a web server instance,
-    ## which by default listens to the @qcode{localhost} on port @qcode{8080}
-    ## and returns its handle to the @qcode{WebServer} object, @var{obj}.
+    ## @code{@var{obj} = WebInstance.instance ()} returns a web server instance.
+    ## If the server has not been initialized before it will be opened listening
+    ## on port @qcode{8080} of the @qcode{localhost}.
     ##
-    ## @code{@var{obj} = WebServer.start (@dots{}, @var{Name}, @var{Value})}
-    ## initializes a WebServer instance with the settings specified by one or
+    ## @code{@var{obj} = WebInstance.instance (@dots{}, @var{Name}, @var{Value})}
+    ## initializes a WebInstance instance with the settings specified by one or
     ## more of the following @qcode{@var{Name}, @var{Value}} pair arguments.
+    ## NOTE: This will only take effect if the WebInstance hasn't been
+    ## initialized before in the same Octave session.
     ##
     ## @multitable @columnfractions 0.18 0.02 0.80
     ## @headitem @var{Name} @tab @tab @var{Value}
@@ -167,19 +168,19 @@ classdef WebServer < handle
     ## bind-address of the web server instance.  The default value is
     ## @qcode{"127.0.0.1"}.
     ##
-    ## @seealso{WebServer}
+    ## @seealso{WebInstance}
     ## @end deftypefn
 
-    function this = start (varargin)
+    function this = instance (varargin)
 
-      persistent instance;
+      persistent singleton_instance;
       mlock ();
 
-      if (isempty (instance))
-        instance = WebServer (varargin{:});
+      if (isempty (singleton_instance))
+        singleton_instance = WebInstance (varargin{:});
       endif
 
-      this = instance;
+      this = singleton_instance;
     endfunction
 
   endmethods


### PR DESCRIPTION
This adds a couple new methods to the `Html` class that allows easy access to the web server from the Charts objects.

It also fixes the destructor of the WebServer class that couldn't be called previously (because it had private access).
